### PR TITLE
Pull Request: Fix Coolify Deployment with Correct Nixpacks Configuration

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,21 +1,11 @@
 [variables]
-NODE_ENV = "production"
-NPM_CONFIG_PRODUCTION = "false"
-
-[phases.setup]
-nixPkgs = ["nodejs_22", "npm-10_x", "openssl"]
-nixLibs = ["gcc-unwrapped"]
-aptPkgs = ["curl", "wget"]
+NIXPACKS_NODE_VERSION = "22"
 
 [phases.install]
-dependsOn = ["setup"]
 cmds = ["npm ci"]
-cacheDirectories = ["/root/.npm"]
 
 [phases.build]
-dependsOn = ["install"]
 cmds = ["npm run build"]
-cacheDirectories = [".next/cache", "node_modules/.cache"]
 
 [start]
 cmd = "npm run start"


### PR DESCRIPTION
## Summary

Fixes Coolify deployment failures by using the proper nixpacks configuration for Node.js 22.

## Problem

- `npm-10_x` and `npm-11_x` are undefined variables in nixpacks
- Manual package specification caused build failures
- Deployment stuck at nixpacks setup phase

## Solution

- Use `NIXPACKS_NODE_VERSION = "22"` environment variable (official method)
- Remove manual `nixPkgs` configuration
- Let nixpacks auto-configure Node.js 22 with bundled npm
- Simplified configuration following nixpacks best practices

## Changes

- Updated `nixpacks.toml` to use proper Node.js version specification
- Removed problematic manual package declarations
- Streamlined build phases for reliability

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
