### PR TITLE
Fix: Image Display and Improve Media Field UX

### DIFF
--- a/src/collections/Portfolio.ts
+++ b/src/collections/Portfolio.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig } from "payload";
-import { createArrayMediaFields, createSingleMediaGroup, createVideoFields } from "../lib/mediaFieldHelpers";
+import { createArrayMediaFields, createFlatMediaGroup, createVideoFields } from "../lib/mediaFieldHelpers";
 
 
 export const Portfolio: CollectionConfig = {
@@ -164,15 +164,13 @@ export const Portfolio: CollectionConfig = {
                         initCollapsed: true,
                         description: "Configure the main hero image and its display settings"
                     },
-                    fields: [
-                        createSingleMediaGroup({
-                            fieldNamePrefix: "hero",
-                            label: "Hero Image",
-                            description: "Configure the main hero image and its display settings",
-                            defaultPosition: "center",
-                            defaultAspectRatio: "landscape",
-                        }),
-                    ],
+                    fields: createFlatMediaGroup({
+                        fieldNamePrefix: "hero",
+                        label: "Hero Image",
+                        description: "Upload the hero image for this section",
+                        defaultPosition: "center",
+                        defaultAspectRatio: "landscape",
+                    }),
                 },
             ],
         },
@@ -432,15 +430,13 @@ export const Portfolio: CollectionConfig = {
                         initCollapsed: true,
                         description: "Configure the image displayed in your about section"
                     },
-                    fields: [
-                        createSingleMediaGroup({
-                            fieldNamePrefix: "about",
-                            label: "About Image",
-                            description: "Configure your profile image and its display settings",
-                            defaultPosition: "center",
-                            defaultAspectRatio: "portrait",
-                        }),
-                    ],
+                    fields: createFlatMediaGroup({
+                        fieldNamePrefix: "about",
+                        label: "About Image",
+                        description: "Upload your profile image for this section",
+                        defaultPosition: "center",
+                        defaultAspectRatio: "portrait",
+                    }),
                 },
             ],
         },

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -43,7 +43,7 @@ interface AboutProps {
         | "top-right"
         | "bottom-left"
         | "bottom-right";
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     imageZoom?: number;
     imageFinePosition?: {
         x?: number;

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -34,7 +34,7 @@ interface HeroProps {
         | "top-right"
         | "bottom-left"
         | "bottom-right";
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     imageZoom?: number;
     imageFinePosition?: {
         x?: number;

--- a/src/components/shared/simple-media-carousel.tsx
+++ b/src/components/shared/simple-media-carousel.tsx
@@ -16,7 +16,7 @@ import { SimpleMedia } from "./simple-media";
 interface SimpleMediaCarouselProps {
     media?: MediaItem | MediaItem[];
     title: string;
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     className?: string;
     priority?: boolean;
 }

--- a/src/components/shared/simple-media.tsx
+++ b/src/components/shared/simple-media.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 interface SimpleMediaProps {
     media?: MediaItem;
     alt: string;
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     className?: string;
     priority?: boolean;
     imageZoom?: number;
@@ -23,7 +23,10 @@ interface SimpleMediaProps {
 const ASPECT_RATIOS: Record<string, number> = {
     square: 1,
     landscape: 16 / 9,
-    portrait: 3 / 4,
+    portrait: 4 / 5,
+    "5/4": 5 / 4,
+    "3/2": 3 / 2,
+    "4/3": 4 / 3,
 } as const;
 
 function getAspectRatioValue(aspectRatio: string): number {

--- a/src/lib/mediaFieldHelpers.ts
+++ b/src/lib/mediaFieldHelpers.ts
@@ -34,9 +34,9 @@ export const ASPECT_RATIO_OPTIONS = [
     { label: "Landscape (16:9)", value: "landscape" },
     { label: "Portrait (4:5)", value: "portrait" },
     { label: "Square (1:1)", value: "square" },
-    { label: "Cinematic (21:9)", value: "21/9" },
+    { label: "Wide (5:4)", value: "5/4" },
+    { label: "Photo (3:2)", value: "3/2" },
     { label: "Classic (4:3)", value: "4/3" },
-    { label: "Golden Ratio (1.618:1)", value: "1.618/1" },
 ];
 
 // ===== MEDIA FIELD FACTORY FUNCTIONS =====
@@ -404,6 +404,117 @@ export const createSingleMediaGroup = (options: {
             },
         ],
     };
+};
+
+/**
+ * Creates a flattened media group without nested collapsibles
+ * Perfect for when you want all media controls in one collapsible level
+ */
+export const createFlatMediaGroup = (options: {
+    fieldNamePrefix: string;
+    label: string;
+    description: string;
+    defaultPosition?: string;
+    defaultAspectRatio?: string;
+}): Field[] => {
+    const {
+        fieldNamePrefix,
+        label,
+        description,
+        defaultPosition = "center",
+        defaultAspectRatio = "landscape"
+    } = options;
+
+    return [
+        {
+            name: `${fieldNamePrefix}Media`,
+            type: "group",
+            label: "Media Settings",
+            fields: [
+                {
+                    name: "image",
+                    type: "upload",
+                    relationTo: "media",
+                    label: label,
+                    admin: {
+                        description: description,
+                    },
+                },
+                {
+                    name: "imagePosition",
+                    type: "select",
+                    label: "Image Position",
+                    defaultValue: defaultPosition,
+                    dbName: "img_pos",
+                    options: IMAGE_POSITION_OPTIONS,
+                    admin: {
+                        description: "Controls how the image is positioned within its container when cropped",
+                        condition: (data, siblingData) => !!siblingData?.image,
+                    },
+                },
+                {
+                    name: "aspectRatio",
+                    type: "select",
+                    label: "Image Aspect Ratio",
+                    defaultValue: defaultAspectRatio,
+                    dbName: "aspect_ratio",
+                    options: ASPECT_RATIO_OPTIONS,
+                    admin: {
+                        description: "Controls the aspect ratio of the image",
+                        condition: (data, siblingData) => !!siblingData?.image,
+                    },
+                },
+                {
+                    name: "imageZoom",
+                    type: "number",
+                    label: "Image Zoom (%)",
+                    min: 50,
+                    max: 200,
+                    admin: {
+                        description: "Scale the image (50-200%). Leave empty for default size.",
+                        placeholder: "Leave empty for default (100%)",
+                        condition: (data, siblingData) => !!siblingData?.image,
+                    },
+                    validate: createZoomValidator(),
+                },
+                {
+                    type: "collapsible",
+                    label: "Fine Position Control (Advanced)",
+                    admin: {
+                        initCollapsed: true,
+                        description: "Precise positioning control (overrides preset position when values are set). Leave empty to use preset position above.",
+                        condition: (data, siblingData) => !!siblingData?.image,
+                    },
+                    fields: [
+                        {
+                            name: "x",
+                            type: "number",
+                            label: "Horizontal Position (%)",
+                            min: 0,
+                            max: 100,
+                            admin: {
+                                description: "Horizontal position (0-100%). Leave empty to use preset position. 0 = left edge, 50 = center, 100 = right edge",
+                                placeholder: "Leave empty for preset position",
+                            },
+                            validate: createPositionValidator("Horizontal position"),
+                        },
+                        {
+                            name: "y",
+                            type: "number",
+                            label: "Vertical Position (%)",
+                            min: 0,
+                            max: 100,
+                            admin: {
+                                description: "Vertical position (0-100%). Leave empty to use preset position. 0 = top edge, 50 = center, 100 = bottom edge",
+                                placeholder: "Leave empty for preset position",
+                            },
+                            validate: createPositionValidator("Vertical position"),
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
 };
 
 /**

--- a/src/lib/payload-utils.ts
+++ b/src/lib/payload-utils.ts
@@ -208,12 +208,12 @@ export function adaptPortfolioData(data: any) {
             title: safeString(data.hero.heroTitle, "UnseenSnick"),
             description: data.hero.heroDescription || null,
             githubUrl: safelyExtractUrl(data.hero.githubUrl, "https://github.com"),
-            image: safelyExtractImageUrl(data.hero.heroImage) || "/placeholder-image.svg",
-            imagePosition: (data.hero.heroImagePosition || "center") as "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",
-            aspectRatio: safeString(data.hero.heroAspectRatio, "landscape"),
-            imageZoom: typeof data.hero.heroImageZoom === "number" ? data.hero.heroImageZoom : undefined,
-            imageFinePosition: (data.hero.x !== undefined || data.hero.y !== undefined) 
-                ? { x: data.hero.x, y: data.hero.y } 
+            image: safelyExtractImageUrl(data.hero.heroMedia?.image) || "/placeholder-image.svg",
+            imagePosition: (data.hero.heroMedia?.imagePosition || "center") as "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",
+            aspectRatio: safeString(data.hero.heroMedia?.aspectRatio, "landscape"),
+            imageZoom: typeof data.hero.heroMedia?.imageZoom === "number" ? data.hero.heroMedia.imageZoom : undefined,
+            imageFinePosition: (data.hero.heroMedia?.x !== undefined || data.hero.heroMedia?.y !== undefined) 
+                ? { x: data.hero.heroMedia.x, y: data.hero.heroMedia.y } 
                 : undefined,
             ctaText: "View GitHub",
             ctaLink: safelyExtractUrl(data.hero.githubUrl, "https://github.com"),
@@ -225,12 +225,12 @@ export function adaptPortfolioData(data: any) {
             content: data.about.content || null,
             technologies: safelyExtractNames(data.about.technologies) || [],
             interests: safelyExtractNames(data.about.interests) || [],
-            image: safelyExtractImageUrl(data.about.aboutImage) || "/placeholder-image.svg",
-            imagePosition: (data.about.aboutImagePosition || "center") as "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",
-            aspectRatio: safeString(data.about.aboutAspectRatio, "portrait"),
-            imageZoom: typeof data.about.aboutImageZoom === "number" ? data.about.aboutImageZoom : undefined,
-            imageFinePosition: (data.about.x !== undefined || data.about.y !== undefined) 
-                ? { x: data.about.x, y: data.about.y } 
+            image: safelyExtractImageUrl(data.about.aboutMedia?.image) || "/placeholder-image.svg",
+            imagePosition: (data.about.aboutMedia?.imagePosition || "center") as "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right",
+            aspectRatio: safeString(data.about.aboutMedia?.aspectRatio, "portrait"),
+            imageZoom: typeof data.about.aboutMedia?.imageZoom === "number" ? data.about.aboutMedia.imageZoom : undefined,
+            imageFinePosition: (data.about.aboutMedia?.x !== undefined || data.about.aboutMedia?.y !== undefined) 
+                ? { x: data.about.aboutMedia.x, y: data.about.aboutMedia.y } 
                 : undefined,
             technologiesHeading: safeString(data.about.technologiesHeading, "Technologies & Tools"),
             interestsHeading: safeString(data.about.interestsHeading, "When I'm Not Coding"),

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -293,7 +293,7 @@ export interface Portfolio {
     githubUrl?: (number | null) | NavigationLink;
     heroMedia?: {
       /**
-       * Upload the image for this section
+       * Upload the hero image for this section
        */
       image?: (number | null) | Media;
       /**
@@ -305,7 +305,7 @@ export interface Portfolio {
       /**
        * Controls the aspect ratio of the image
        */
-      aspectRatio?: ('landscape' | 'portrait' | 'square' | '21/9' | '4/3' | '1.618/1') | null;
+      aspectRatio?: ('landscape' | 'portrait' | 'square' | '5/4' | '3/2' | '4/3') | null;
       /**
        * Scale the image (50-200%). Leave empty for default size.
        */
@@ -399,7 +399,7 @@ export interface Portfolio {
                 /**
                  * Controls the aspect ratio of this media item. Applies to both images and videos.
                  */
-                aspectRatio?: ('landscape' | 'portrait' | 'square' | '21/9' | '4/3' | '1.618/1') | null;
+                aspectRatio?: ('landscape' | 'portrait' | 'square' | '5/4' | '3/2' | '4/3') | null;
                 /**
                  * Scale the image (50-200%). Leave empty for default size. Useful for fitting images better within the aspect ratio.
                  */
@@ -494,7 +494,7 @@ export interface Portfolio {
     interests?: (number | Tag)[] | null;
     aboutMedia?: {
       /**
-       * Upload the image for this section
+       * Upload your profile image for this section
        */
       image?: (number | null) | Media;
       /**
@@ -506,7 +506,7 @@ export interface Portfolio {
       /**
        * Controls the aspect ratio of the image
        */
-      aspectRatio?: ('landscape' | 'portrait' | 'square' | '21/9' | '4/3' | '1.618/1') | null;
+      aspectRatio?: ('landscape' | 'portrait' | 'square' | '5/4' | '3/2' | '4/3') | null;
       /**
        * Scale the image (50-200%). Leave empty for default size.
        */

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -18,7 +18,7 @@ export interface Hero {
     githubUrl: string;
     image: string;
     imagePosition?: "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     imageZoom?: number;
     imageFinePosition?: {
         x?: number;
@@ -37,7 +37,7 @@ export interface About {
     interests: string[];
     image: string;
     imagePosition?: "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     imageZoom?: number;
     imageFinePosition?: {
         x?: number;
@@ -58,7 +58,7 @@ export interface MediaItem {
         alt?: string;
     } | any;
     imagePosition?: "center" | "top" | "bottom" | "left" | "right" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
-    aspectRatio?: "square" | "landscape" | "portrait" | string;
+    aspectRatio?: "square" | "landscape" | "portrait" | "5/4" | "3/2" | "4/3" | string;
     imageZoom?: number;
     imageFinePosition?: {
         x?: number;


### PR DESCRIPTION
# Pull Request: Fix Image Display and Improve Media Field UX

## Summary

Fixes UploadThing image display issues and improves PayloadCMS media field user experience with better aspect ratios and flattened field structure.

## Problem

- UploadThing images not displaying in hero/about sections due to incorrect field path extraction
- Limited aspect ratio options causing poor image fitting
- Nested collapsible fields creating unnecessary UI complexity in admin

## Solution

- Fixed image extraction paths to match PayloadCMS nested media structure
- Added practical aspect ratio options (Wide 5:4, Photo 3:2, Classic 4:3)
- Created flattened media field structure to reduce admin UI nesting
- Updated TypeScript types across all components

## Changes

- **Fixed image display**: Updated `payload-utils.ts` to extract from `heroMedia.image` instead of `heroImage`
- **Better aspect ratios**: Replaced impractical ratios (21:9, golden ratio) with useful ones
- **Flattened UI**: Created `createFlatMediaGroup()` to reduce collapsible nesting in hero/about sections
- **Type updates**: Added new aspect ratio types to all components and interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
